### PR TITLE
友達申請機能の基本実装（モデル・UI・再申請防止）

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -18,6 +18,13 @@ class FriendshipsController < ApplicationController
     
     # friendshipsのenumを利用して、簡単に記述
     @sent_requests = current_user.friendships.pending
-    @receives_requests = current_user.inverse_friendships.pending
+    @received_requests = current_user.inverse_friendships&.pending || []
+  end
+
+  # 友達リストの表示
+  def accepted
+    # &:friend → do |f| f.friend end の省略記法.
+    # Friendshipオブジェクトから関連づけられた「friend(User)」だけを取り出す。=> 「承認済みFriendshipの相手ユーザー」だけを集めた配列になる
+    @friends = current_user.friendships.accepted.map(&:friend)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   has_many :friendships, dependent: :destroy
   has_many :friends, through: :friendships, source: :friend
 
-  # 自分への申請
+  # 自分への申請(逆方向の関連)
   has_many :inverse_friendships,
             class_name: 'Friendship',
             foreign_key: 'friend_id',

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,11 +1,22 @@
 <h2>ユーザー一覧</h2>
 <% @users.each do |user| %>
-  <% unless current_user.friends.include?(user) %>
+  <% next if current_user == user %>
+
+  <% friendship = current_user.friendships.find_by(friend: user) %>
+
+  <% if friendship&.pending? %>
+    <p><%= user.username %>（申請中）</p>
+
+  <% elsif friendship&.accepted? %>
+    <p><%= user.username %>（友達）</p>
+
+  <% elsif friendship&.blocked? %>
+    <p><%= user.username %>（申請拒否済み）</p>
+
+  <% else %>
     <p>
-      <%= user.username %>  
+      <%= user.username %>
       <%= button_to "申請する", friendships_path(friend_id: user.id), method: :post %>
     </p>
-  <% else %>
-    <p><%= user.username %>（申請済みまたは友達）</p>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 概要
Friendshipモデルを作成し、ユーザー間の友達申請機能の基本部分を実装

## 実装内容
- Friendshipモデルの作成 (enum: pending / accepted / blockesd)
- user と friend のアソシエーション定義
- 重複申請防止のバリデーション追加
- UI側で申請済みユーザーの表示切り替え
