### PR TITLE
feat: 友達申請の承認・拒否・解除機能と承認済み一覧を実装

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -42,7 +42,7 @@ class FriendshipsController < ApplicationController
       if friendship.accepted?
         # 承認済みを削除 = 友達解除
         "友達を解除しました"
-      elsif friendship.pnefing?
+      elsif friendship.pending?
         # 未承認を削除 = 申請拒否 or 申請キャンセル
         friendship.user_id == current_user.id ? "申請を取り消しました" : "申請を拒否しました"
       else

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -62,4 +62,16 @@ class FriendshipsController < ApplicationController
     # Friendshipオブジェクトから関連づけられた「friend(User)」だけを取り出す。=> 「承認済みFriendshipの相手ユーザー」だけを集めた配列になる
     @friends = current_user.friendships.accepted.includes(:friend).map(&:friend)
   end
+
+  def update
+    friendship = Friendship.find_by(id: params[:id])
+    result, message = FriendshipAcceptor.new(friendship, current_user).call
+
+    if result
+      redirect_to friendships_path, notice: message
+    else
+      redirect_back fallback_location: friendships_path, alert: message
+    end
+  end
+
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,8 +1,21 @@
 class FriendshipsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    # 最初に記述したコード
+    # @sent_requests = currnet_user.friendships.where(status: :pending)
+    # @received_requests = current_user.inverse_friendships.where(status: :pending)
+    # friendshipsのenumを利用して、簡単に記述
+    @sent_requests = current_user.friendships.pending
+
+    @received_requests = current_user.inverse_friendships.pending
+    # inverse_friendships は常に ActiveRecord::Relation（空の配列相当）を返すため、 &.pending || [] の &. と || [] は冗長
+    # “逆方向の関連がないときに nil” という独自実装がなければ、&. は不要
+    # @received_requests = current_user.inverse_friendships&.pending || []
+  end
+
   def create
-    # 存在しないIDなら nil を返す
     friend = User.find_by(id: params[:friend_id])
-    
     # user が見つからなかった場合のハンドリング
     unless friend
       redirect_to users_path, alert: "申請相手のユーザーが見つかりません。"
@@ -17,24 +30,36 @@ class FriendshipsController < ApplicationController
     end
   end
 
-  def index
-    # 最初に記述したコード
-    # @sent_requests = currnet_user.friendships.where(status: :pending)
-    # @received_requests = current_user.inverse_friendships.where(status: :pending)
-    
-    # friendshipsのenumを利用して、簡単に記述
-    @sent_requests = current_user.friendships.pending
+  # 拒否 or 解除: 送受信いずれの申請/関係でも自分が当事者なら削除可
+  def destroy
+    friendship = Friendship.find_by(id: params[:id])
+    unless friendship && [friendship.user_id, friendship.friend_id].include?(current_user.id)
+      redirect_back fallback_location: friendships_path, alert: "操作権限がありません。"
+      return
+    end
 
-    @received_requests = current_user.inverse_friendships.pending
-    # inverse_friendships は常に ActiveRecord::Relation（空の配列相当）を返すため、 &.pending || [] の &. と || [] は冗長
-    # “逆方向の関連がないときに nil” という独自実装がなければ、&. は不要
-    # @received_requests = current_user.inverse_friendships&.pending || []
+    label = 
+      if friendship.accepted?
+        # 承認済みを削除 = 友達解除
+        "友達を解除しました"
+      elsif friendship.pnefing?
+        # 未承認を削除 = 申請拒否 or 申請キャンセル
+        friendship.user_id == current_user.id ? "申請を取り消しました" : "申請を拒否しました"
+      else
+        "関係を削除しました"
+      end
+
+      if friendship.destroy
+        redirect_back fallback_location: friendships_path, notice: label
+      else
+        redirect_back fallback_location: friendhips_path, alert: "削除に失敗しました。"
+      end
   end
 
   # 友達リストの表示
   def accepted
     # &:friend → do |f| f.friend end の省略記法.
     # Friendshipオブジェクトから関連づけられた「friend(User)」だけを取り出す。=> 「承認済みFriendshipの相手ユーザー」だけを集めた配列になる
-    @friends = current_user.friendships.accepted.map(&:friend)
+    @friends = current_user.friendships.accepted.includes(:friend).map(&:friend)
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -2,16 +2,8 @@ class FriendshipsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    # 最初に記述したコード
-    # @sent_requests = currnet_user.friendships.where(status: :pending)
-    # @received_requests = current_user.inverse_friendships.where(status: :pending)
-    # friendshipsのenumを利用して、簡単に記述
     @sent_requests = current_user.friendships.pending
-
     @received_requests = current_user.inverse_friendships.pending
-    # inverse_friendships は常に ActiveRecord::Relation（空の配列相当）を返すため、 &.pending || [] の &. と || [] は冗長
-    # “逆方向の関連がないときに nil” という独自実装がなければ、&. は不要
-    # @received_requests = current_user.inverse_friendships&.pending || []
   end
 
   def create
@@ -40,11 +32,13 @@ class FriendshipsController < ApplicationController
 
     label = 
       if friendship.accepted?
-        # 承認済みを削除 = 友達解除
         "友達を解除しました"
       elsif friendship.pending?
-        # 未承認を削除 = 申請拒否 or 申請キャンセル
-        friendship.user_id == current_user.id ? "申請を取り消しました" : "申請を拒否しました"
+        if friendship.user_id == current_user.id
+          "送信した申請をキャンセルしました"
+        else
+          "受信した申請を拒否しました"
+        end
       else
         "関係を削除しました"
       end

--- a/app/services/friendship_acceptor.rb
+++ b/app/services/friendship_acceptor.rb
@@ -1,0 +1,26 @@
+class FriendshipAcceptor
+  def initialize(friendship, current_user)
+    @friendship = friendship
+    @current_user = current_user
+  end
+
+  def call
+    # nullチェックと認可を単一のプライベートメソッドで処理
+    return false, '承認権限がありません' unless authorization_valid?
+
+    # 更新を実行
+    if @friendship.update(status: :accepted)
+      return true, "#{@friendship.friend.username} さんと友達になりました"
+    else
+      return false, '承認に失敗しました'
+    end
+  end
+
+  private
+
+  def authorization_valid?
+    @friendship.present? &&
+      @friendship.pending? &&
+      @friendship.friend_id == @current_user.id
+  end
+end

--- a/app/views/friendships/accepted.html.erb
+++ b/app/views/friendships/accepted.html.erb
@@ -1,0 +1,15 @@
+<h2>友達リスト</h2>
+<% if @friends.any? %>
+  <% @friends.each do |friend| %>
+    <p>
+      ⚫︎ <%= friend.username %>
+      <% if (f = current_user.sent_friendship_to(friend)) %>
+        <%= button_to "解除", friendship_path(f), method: :delete, data: { confirm: "友達を解除しますか？" } %>
+      <% elsif (f = current_user.received_friendship_from(friend)) %>
+        <%= button_to "解除", friendship_path(f), method: :delete, data: { confirm: "友達を解除しますか？" } %>
+      <% end %>
+    </p>
+  <% end %>
+<% else %>
+  <p>友達がいません</p>
+<% end %>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,12 +1,18 @@
 <h2>送信した申請</h2>
 <% @sent_requests.each do |f| %>
-  <p>→ <%= f.friend.username %> （申請中）</p>
+  <p>
+    → <%= f.friend.username %>（申請中）
+    <%= button_to "取り消し", friendship_path(f), method: :delete, data: { confirm: "申請を取り消しますか？" } %>
+  </p>
 <% end %>
 
 <h2>受信した申請</h2>
 <% @received_requests.each do |f| %>
-  <p><%= f.user.username %>
+  <p>
+    <%= f.user.username %>
     <%= button_to "承認", friendship_path(f), method: :patch %>
     <%= button_to "拒否", friendship_path(f), method: :delete, data: { confirm: "本当に拒否しますか？" } %>
   </p>
 <% end %>
+
+<p><%= link_to "友達一覧へ", accepted_friendships_path %></p>


### PR DESCRIPTION
2025-09-26
destroyアクションのメッセージを
- 送信者 = キャンセル
- 受信者 = 拒否
と明確化しました

---
2025-09-23
## FriendshipsController の更新
* indexアクション
* createアクション
* updateアクション
* destroyアクション
* acceptedアクション

## サービスオブジェクトapp/services/friendship_acceptor.rb の作成

## app/views/friendships/index.html.erb の更新

## app/views/friendships/accepted.html.erb の作成