### PR TITLE
feat: 拒否・拒否解除機能を追加

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -66,4 +66,35 @@ class FriendshipsController < ApplicationController
     end
   end
 
+  def reject
+    friendship = Friendship.find_by(id: params[:id])
+
+    unless friendship && friendship.friend_id == current_user.id
+      redirect_back fallback_location: friendships_path, alert: "操作権限がありません。"
+      return
+    end
+
+    if friendship.pending?
+      friendship.update(status: :blocked)
+      redirect_to friendships_path, notice: "申請を拒否しました"
+    else
+      redirect_back fallback_location: friendships_path, alert: "この申請は拒否できません。"
+    end
+  end
+
+  def unblock
+    friendship = Friendship.find_by(id: params[:id])
+
+    unless friendship && friendship.friend_id == current_user.id
+      redirect_back fallback_locationn: friendships_path, alert: "操作権限がありません"
+      return
+    end
+
+    if friendship.blocked?
+      friendship.destroy
+      redirect_to friendships_path, notice: "拒否を解除しました"
+    else
+      redirect_back fallback_location: friendships_path, alert: "この申請は拒否解除できません"
+    end
+  end
 end

--- a/app/helpers/friendships_helper.rb
+++ b/app/helpers/friendships_helper.rb
@@ -2,6 +2,7 @@
 module FriendshipsHelper
   def friendship_action(user, target_user)
     status = user.friendship_status_with(target_user)
+    friendship = user.sent_friendship_to(target_user) || user.received_friendship_from(target_user)
 
     case status
     when :pending
@@ -9,7 +10,13 @@ module FriendshipsHelper
     when :accepted
       content_tag(:span, '友達')
     when :blocked
-      content_tag(:span, '申請拒否済み')
+      if friendship&.friend_id == current_user.id
+        content_tag(:span, '申請拒否済み') +
+          button_to("拒否解除", unblock_friendship_path(friendship), method: :delete, data: { turbo_confirm: "拒否を解除しますか？" })
+      else
+        content_tag(:span, '申請拒否されました')
+      end
+    
     else
       button_to '申請する',
                 friendships_path(friend_id: target_user.id),

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 
-import "@rails/ujs"
 import "@hotwired/turbo-rails"
 import "controllers"
-
-Rails.start()

--- a/app/views/friendships/accepted.html.erb
+++ b/app/views/friendships/accepted.html.erb
@@ -4,9 +4,9 @@
     <p>
       ⚫︎ <%= friend.username %>
       <% if (f = current_user.sent_friendship_to(friend)) %>
-        <%= button_to "解除", friendship_path(f), method: :delete, data: { confirm: "友達を解除しますか？" } %>
+        <%= button_to "解除", friendship_path(f), method: :delete, data: { turbo_confirm: "友達を解除しますか？" } %>
       <% elsif (f = current_user.received_friendship_from(friend)) %>
-        <%= button_to "解除", friendship_path(f), method: :delete, data: { confirm: "友達を解除しますか？" } %>
+        <%= button_to "解除", friendship_path(f), method: :delete, data: { turbo_confirm: "友達を解除しますか？" } %>
       <% end %>
     </p>
   <% end %>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -2,7 +2,7 @@
 <% @sent_requests.each do |f| %>
   <p>
     → <%= f.friend.username %>（申請中）
-    <%= button_to "取り消し", friendship_path(f), method: :delete, data: { confirm: "申請を取り消しますか？" } %>
+    <%= button_to "取り消し", friendship_path(f), method: :delete, data: { turbo_confirm: "申請を取り消しますか？" } %>
   </p>
 <% end %>
 
@@ -11,7 +11,7 @@
   <p>
     <%= f.user.username %>
     <%= button_to "承認", friendship_path(f), method: :patch %>
-    <%= button_to "拒否", friendship_path(f), method: :delete, data: { confirm: "本当に拒否しますか？" } %>
+    <%= button_to "拒否", reject_friendship_path(f), method: :patch, data: { turbo_confirm: "本当に拒否しますか？" } %>
   </p>
 <% end %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,7 @@
 <h2>ユーザー一覧</h2>
 <% @users.each do |user| %>
-  <p><%= user.username %> <%= friendship_action(current_user, user) %></p>
+  <p>
+    <%= user.username %>
+    <%= friendship_action(current_user, user) %>
+  </p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
     collection do
       get :accepted
     end
+    member do
+      patch :reject
+      delete :unblock
+    end
   end
+
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## Friendship における「拒否」「拒否解除」機能を実装
- 拒否時は statusを blockedに更新
- 拒否解除時は Friendshipレコードを削除し再申請可能に戻す
- ビューに確認ダイアログを追加（Turbo confirm)

- ルーティングに reject、unblockアクション追加
- Friendhipsコントローラーに reject、unblockメソッド追加