### PR TITLE
user.rb相手との関係状態を返すメソッドをfriendship.rbへ移行、論理削除の導入

### DIFF
--- a/app/controllers/friend_requests_controller.rb
+++ b/app/controllers/friend_requests_controller.rb
@@ -2,21 +2,30 @@ class FriendRequestsController < ApplicationController
   before_action :authenticate_user!
   def create
     friend = User.find(params[:friend_id])
+    
+    return redirect_to(users_path, alert: '自分には申請できません') if friend == current_user
+    return redirect_to(users_path, alert: 'すでに友達です') if current_user.friend_with?(friend)
 
-    # すでに友達なら申請させない
-    if current_user.friendship_with(friend).present?
-      return redirect_to users_path, alert: "すでに友達です"
+    # 相手→自分の申請がpendingなら二重を作らない
+    reverse = FriendRequest.find_by(user: friend, friend: current_user)
+    if reverse&.pending?
+      return redirect_to(users_path, alert: '相手から申請が届いています')
     end
 
-    request = current_user.friend_requests.find_or_initialize_by(friend: friend)
+    request = 
+      current_user.friend_requests.find_or_initialize_by(friend: friend)
 
-    # accepted / rejected なら再申請として pending に戻す
-    if request.accepted? || request.rejected?
-      request.status = :pending
+    # すでに申請中なら何もしない（二重送信防止）
+    if request.persisted? && request.pending?
+      return redirect_to users_path, alert: 'すでに申請済みです'
     end
+
+    # 履歴は残しつつ、再申請は同一レコードを pending に戻す
+    # accepted / rejected / nil（新規）いずれでも pending にする
+    request.status = :pending
 
     if request.save
-      redirect_to users_path, notice: "友達申請を送信しました"
+      redirect_to users_path, notice: '友達申請を送信しました'
     else
       redirect_to users_path, alert: request.errors.full_messages.to_sentence
     end
@@ -25,29 +34,33 @@ class FriendRequestsController < ApplicationController
   def update
     @friend_request = FriendRequest.find(params[:id])
 
-    case params[:status]
-    when "accepted"
+    action = params[:status]&.to_sym
+
+    case action
+    when :accepted
       # 受け取った人だけが承認できる
-      return redirect_to(users_path, alert: "権限がありません") unless @friend_request.friend == current_user
+      return redirect_to(users_path, alert: '権限がありません') unless @friend_request.friend == current_user
 
+      raise ActiveRecord::RecordInvalid unless @friend_request.friend == current_user
+      
       accept_request!
-      redirect_to users_path, notice: "友達になりました"
+      redirect_to users_path, notice: '友達になりました'
 
-    when "rejected"
-      return redirect_to(users_path, alert: "権限がありません") unless @friend_request.friend == current_user
+    when :rejected
+      return redirect_to(users_path, alert: '権限がありません') unless @friend_request.friend == current_user
 
       @friend_request.update!(status: :rejected)
-      redirect_to users_path, notice: "友達申請を拒否しました"
+      redirect_to users_path, notice: '友達申請を拒否しました'
 
-    when "pending"
+    when :pending
       # 再申請=送った人だけが pending にできる
-      return redirect_to(users_path, alert: "権限がありません") unless @friend_request.user == current_user
+      return redirect_to(users_path, alert: '権限がありません') unless @friend_request.user == current_user
 
       @friend_request.update!(status: :pending)
-      redirect_to users_path, notice: "申請を再開しました"
+      redirect_to users_path, notice: '申請を再開しました'
 
     else
-      redirect_to users_path, alert: "不正な操作です"
+      redirect_to users_path, alert: '不正な操作です'
     end
   end
 

--- a/app/controllers/friend_requests_controller.rb
+++ b/app/controllers/friend_requests_controller.rb
@@ -1,7 +1,42 @@
 class FriendRequestsController < ApplicationController
+  before_action :authenticate_user!
   def create
+    friend = User.find(params[:friend_id])
+
+    @request = current_user.friend_requests.new(friend: friend)
+
+    if @request.save
+      redirect_to users_path, notice: "友達申請を送信しました"
+    else
+      redirect_to users_path, alert: @request.errors.full_messages.to_sentence
+    end
   end
 
   def update
+    @friend_request = FriendRequest.find(params[:id])
+
+    case params[:status]
+    when "accepted"
+      accept_request!
+      redirect_to users_path, notice: "友達になりました"
+    when "rejected"
+      @friend_request.update!(status: :rejected)
+      redirect_to users_path, notice: "友達申請を拒否しました"
+    else
+      redirect_to users_path, alert: "不正な操作です"
+    end
+  end
+
+  private
+
+  def accept_request!
+    ActiveRecord::Base.transaction do
+      friendship = Friendship.create!(status: :active)
+
+      FriendshipUser.create!(user: @friend_request.user, friendship: friendship)
+      FriendshipUser.create!(user: @friend_request.friend, friendship: friendship)
+
+      @friend_request.update!(status: :accepted)
+    end
   end
 end

--- a/app/controllers/friend_requests_controller.rb
+++ b/app/controllers/friend_requests_controller.rb
@@ -1,0 +1,7 @@
+class FriendRequestsController < ApplicationController
+  def create
+  end
+
+  def update
+  end
+end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -8,8 +8,10 @@ class FriendshipsController < ApplicationController
 
   # 友達解除
   def destroy
-    friendship = current_user.friendships.find(params[:id])
-    friendship.destroy!
-    redirect_to friendships_path, notice: "友達を解除しました"
+  friendship = current_user.friendships.find(params[:id]) ||
+               Friendship.find_by(user: params[:id], friend: current_user)
+
+  friendship.update!(status: :inactive, deleted_at: Time.current)
+  redirect_to friendships_path, notice: "友達を解除しました"
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -8,10 +8,11 @@ class FriendshipsController < ApplicationController
 
   # 友達解除
   def destroy
-  friendship = current_user.friendships.find(params[:id]) ||
-               Friendship.find_by(user: params[:id], friend: current_user)
+    friendship = current_user.friendships.find(params[:id])
+    friendship.update!(status: :inactive, deleted_at: Time.current)
 
-  friendship.update!(status: :inactive, deleted_at: Time.current)
-  redirect_to friendships_path, notice: "友達を解除しました"
+    redirect_to friendships_path, notice: "友達を解除しました"
+  rescue ActiveRecord::RecordNotFound
+    redirect_to friendships_path, alert: "友達が見つかりませんでした"
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -9,7 +9,7 @@ class FriendshipsController < ApplicationController
   # 友達解除
   def destroy
     friendship = current_user.friendships.find(params[:id])
-    friendship.update!(status: :inactive, deleted_at: Time.current)
+    friendship.update!(status: :inactive)
 
     redirect_to friendships_path, notice: "友達を解除しました"
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -4,6 +4,15 @@ class FriendshipsController < ApplicationController
   # 現在の友達一覧
   def index
     @friends = current_user.friends
+
+    @friendships_by_friend_id =
+      current_user.friendships
+                  .active
+                  .includes(:users)
+                  .each_with_object({}) do |friendship, hash|
+                    other = (friendship.users - [current_user]).first
+                    hash[other.id] = friendship if other
+                  end
   end
 
   # 友達解除
@@ -11,8 +20,8 @@ class FriendshipsController < ApplicationController
     friendship = current_user.friendships.find(params[:id])
     friendship.update!(status: :inactive)
 
-    redirect_to friendships_path, notice: "友達を解除しました"
+    redirect_to friendships_path, notice: '友達を解除しました'
   rescue ActiveRecord::RecordNotFound
-    redirect_to friendships_path, alert: "友達が見つかりませんでした"
+    redirect_to friendships_path, alert: '友達が見つかりませんでした'
   end
 end

--- a/app/helpers/friend_requests_helper.rb
+++ b/app/helpers/friend_requests_helper.rb
@@ -1,0 +1,2 @@
+module FriendRequestsHelper
+end

--- a/app/models/friend_request.rb
+++ b/app/models/friend_request.rb
@@ -2,7 +2,7 @@ class FriendRequest < ApplicationRecord
   enum status: { pending: 0, accepted: 1, rejected: 2 }
   
   belongs_to :user
-  belongs_to :friend, class_name: "User"
+  belongs_to :friend, class_name: 'User'
 
   validates :user_id, uniqueness: { scope: :friend_id }
   validate :not_self
@@ -10,6 +10,6 @@ class FriendRequest < ApplicationRecord
   private
 
   def not_self
-    errors.add(:friend_id, "に自分は指定できません") if user_id == friend_id
+    errors.add(:friend_id, 'に自分は指定できません') if user_id == friend_id
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,22 +1,36 @@
 class Friendship < ApplicationRecord
   belongs_to :user
-  belongs_to :friend, class_name: 'User'
+  belongs_to :friend, class_name: "User"
+
+  before_validation :normalize_user_ids
 
   validates :user_id, uniqueness: { scope: :friend_id }
   validate :not_self
 
   enum status: { active: 0, inactive: 1 }
 
-  def self.status_between(user, other_user)
-    friendship = find_by(user: user, friend: other_user ) ||
-                  find_by(user: other_user, friend: user)
-    return :none unless friendship
-    friendship.active? ? :friend : :inactive
+  scope :alive, -> { where(deleted_at: nil) }
+
+  def self.between(user, other_user)
+    ids = [user.id, other_user.id].sort
+    alive.find_by(user_id: ids[0], friend_id: ids[1])
   end
-  
+
+  def other_for(user)
+    user_id == user.id ? frined : user
+  end
+
   private
-  
+
+  def normalize_user_ids
+    return if user_id.blank? || friend_id.blank?
+
+    if user_id > friend_id
+      self.user_id, self.friend_id = friend_id, user_id
+    end
+  end
+
   def not_self
-    errors.add(:friend_id, "に自分は指定できません") if user_id == friend_id  
+    errors.add(:friend_id, "に自分は指定できません") if user_id == friend_id
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -4,20 +4,4 @@ class Friendship < ApplicationRecord
   has_many :friendship_users, dependent: :destroy
   has_many :users, through: :friendship_users
 
-  scope :alive, -> { where(deleted_at: nil) }
-
-  def self.between(user1, user2)
-    alive
-      .joins(:friendship_users)
-      .where(friendship_users: { user_id: [user1.id, user2.id] })
-      .group("friendships.id")
-      .having("COUNT(friendship_users.user_id) = 2")
-      .first
-  end
-
-  def self.status_between(user1, user2)
-    friendship = between(user1, user2)
-    return :none unless friendship
-    friendship.active? ? :friend : :inactive
-  end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,36 +1,23 @@
 class Friendship < ApplicationRecord
-  belongs_to :user
-  belongs_to :friend, class_name: "User"
-
-  before_validation :normalize_user_ids
-
-  validates :user_id, uniqueness: { scope: :friend_id }
-  validate :not_self
-
   enum status: { active: 0, inactive: 1 }
+
+  has_many :friendship_users, dependent: :destroy
+  has_many :users, through: :friendship_users
 
   scope :alive, -> { where(deleted_at: nil) }
 
-  def self.between(user, other_user)
-    ids = [user.id, other_user.id].sort
-    alive.find_by(user_id: ids[0], friend_id: ids[1])
+  def self.between(user1, user2)
+    alive
+      .joins(:friendship_users)
+      .where(friendship_users: { user_id: [user1.id, user2.id] })
+      .group("friendships.id")
+      .having("COUNT(friendship_users.user_id) = 2")
+      .first
   end
 
-  def other_for(user)
-    user_id == user.id ? frined : user
-  end
-
-  private
-
-  def normalize_user_ids
-    return if user_id.blank? || friend_id.blank?
-
-    if user_id > friend_id
-      self.user_id, self.friend_id = friend_id, user_id
-    end
-  end
-
-  def not_self
-    errors.add(:friend_id, "に自分は指定できません") if user_id == friend_id
+  def self.status_between(user1, user2)
+    friendship = between(user1, user2)
+    return :none unless friendship
+    friendship.active? ? :friend : :inactive
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -5,6 +5,15 @@ class Friendship < ApplicationRecord
   validates :user_id, uniqueness: { scope: :friend_id }
   validate :not_self
 
+  enum status: { active: 0, inactive: 1 }
+
+  def self.status_between(user, other_user)
+    friendship = find_by(user: user, friend: other_user ) ||
+                  find_by(user: other_user, friend: user)
+    return :none unless friendship
+    friendship.active? ? :friend : :inactive
+  end
+  
   private
   
   def not_self

--- a/app/models/friendship_user.rb
+++ b/app/models/friendship_user.rb
@@ -1,0 +1,6 @@
+class FriendshipUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :friendship
+
+  validates :user_id, uniqueness: { scope: :friendship_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,22 @@ class User < ApplicationRecord
                 .reject { |u| u.id == id }
   end
 
+  # 自分とother_userの間のacitveなFriendshipを1件返す
+  def friendship_with(other_user)
+    my_ids = friendship_users.select(:friendship_id)
+    Friendship.active
+              .joins(:friendship_users)
+              .where(id: my_ids)
+              .where(friendship_users: { user_id: other_user.id })
+              .first
+
+    return nil if other_user == self
+  
+  end
+
+  # 友達かどうか？
   def friend_with?(other_user)
-    Friendship.status_between(self, other_user) == :friend
+    friendship_with(other_user).present?
   end
 
   # 自分が送った申請（FriendRequest）

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,32 +2,24 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-  # 自分から送った友達関係
-  has_many :friendships, dependent: :destroy
-
-  # 自分への友達関係
-  has_many :inverse_friendships,
-           class_name: 'Friendship',
-           foreign_key: 'friend_id',
-           dependent: :destroy
-  has_many :inverse_friends, through: :inverse_friendships, source: :user
-
-  # 友達申請
-  has_many :friend_requests, dependent: :destroy
-  has_many :received_friend_requests,
-           class_name: "FriendRequest",
-           foreign_key: "friend_id",
-           dependent: :destroy
+  has_many :friendship_users, dependent: :destroy
+  has_many :friendships, through: :friendship_users
 
   validates :username,
             presence: true,
             uniqueness: { case_sensitive: false },
             length: { minimum: 3, maximum: 20 }
 
-  # 現在の友達一覧
   def friends
-    friendships.includes(:friend).map(&:friend) +
-      inverse_friendships.includes(:user).map(&:user)
+    friendships.active
+                .includes(:users)
+                .flat_map(&:users)
+                .uniq
+                .reject { |u| u.id == id }
+  end
+
+  def friend_with?(other_user)
+    Friendship.status_between(self, other_user) == :friend
   end
 
   # 自分が送った申請（FriendRequest）
@@ -39,10 +31,4 @@ class User < ApplicationRecord
   def received_request_from(other_user)
     received_friend_requests.find_by(user: other_user)
   end
-
-  # 友達であるかどうかの判定
-  def friend_with?(other_user)
-    friends.include?(other_user)
-  end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,12 @@ class User < ApplicationRecord
   has_many :friendship_users, dependent: :destroy
   has_many :friendships, through: :friendship_users
 
+  has_many :friend_requests, dependent: :destroy
+  has_many :received_friend_requests,
+            class_name: "FriendRequest",
+            foreign_key: "friend_id",
+            dependent: :destroy
+
   validates :username,
             presence: true,
             uniqueness: { case_sensitive: false },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ApplicationRecord
 
   has_many :friend_requests, dependent: :destroy
   has_many :received_friend_requests,
-            class_name: "FriendRequest",
-            foreign_key: "friend_id",
+            class_name: 'FriendRequest',
+            foreign_key: 'friend_id',
             dependent: :destroy
 
   validates :username,
@@ -24,22 +24,21 @@ class User < ApplicationRecord
                 .reject { |u| u.id == id }
   end
 
-  # 自分とother_userの間のacitveなFriendshipを1件返す
-  def friendship_with(other_user)
-    my_ids = friendship_users.select(:friendship_id)
-    Friendship.active
-              .joins(:friendship_users)
-              .where(id: my_ids)
-              .where(friendship_users: { user_id: other_user.id })
-              .first
-
-    return nil if other_user == self
-  
-  end
-
-  # 友達かどうか？
+  # 友達かどうかの判定
   def friend_with?(other_user)
     friendship_with(other_user).present?
+  end
+
+  # 友達関係のレコード取得
+  def friendship_with(other_user)
+    return if other_user == self
+
+    common_ids = 
+      friendship_users
+        .select(:friendship_id)
+        .where(friendship_id: other_user.friendship_users.select(:friendship_id))
+
+    friendships.active.find_by(id: common_ids)
   end
 
   # 自分が送った申請（FriendRequest）
@@ -51,4 +50,6 @@ class User < ApplicationRecord
   def received_request_from(other_user)
     received_friend_requests.find_by(user: other_user)
   end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,19 +45,4 @@ class User < ApplicationRecord
     friends.include?(other_user)
   end
 
-  # 相手との関係状態を返す
-  def friendship_status_with(other_user)
-    return :self if self == other_user
-    return :friend if friend_with?(other_user)
-
-    if sent_request_to(other_user)&.pending?
-      return :request_sent
-    elsif received_request_from(other_user)&.pending?
-      return :request_received
-    elsif sent_request_to(other_user)&.rejected?
-      return :request_rejected
-    end
-
-    :none
-  end
 end

--- a/app/views/friend_requests/create.html.erb
+++ b/app/views/friend_requests/create.html.erb
@@ -1,0 +1,2 @@
+<h1>FriendRequests#create</h1>
+<p>Find me in app/views/friend_requests/create.html.erb</p>

--- a/app/views/friend_requests/update.html.erb
+++ b/app/views/friend_requests/update.html.erb
@@ -1,0 +1,2 @@
+<h1>FriendRequests#update</h1>
+<p>Find me in app/views/friend_requests/update.html.erb</p>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,13 +1,15 @@
 <h2>友達リスト</h2>
 
 <% if @friends.any? %>
-  <% @friends.each do |friend| %>
+  <% @friend.each do |friend| %>
     <p>
       ⚫︎ <%= friend.username %>
-      <% if (f = Friendship.find_by(user: current_user, friend: friend)) %>
-        <%= button_to "解除", friendship_path(f), method: :delete, data: { turbo_confirm: "友達を解除しますか？" } %>
-      <% elsif (f = Friendship.find_by(user: friend, friend: current_user)) %>
-        <%= button_to "解除", friendship_path(f), method: :delete, data: { turbo_confirm: "友達を解除しますか？" } %>
+      <% if (f = Friendship.status_between(current_user, friend)) == :friend %>
+        <%= button_to "解除",
+                      friendship_path(Friendship.find_by(user: current_user, friend: friend) ||
+                                      Friendship.find_by(user: friend, friend: current_user)),
+                                      method: :delete,
+                                      data: { turbo_confirm: "友達を解除しますか？" } %>
       <% end %>
     </p>
   <% end %>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,13 +1,12 @@
 <h2>友達リスト</h2>
 
 <% if @friends.any? %>
-  <% @friend.each do |friend| %>
+  <% @friends.each do |friend| %>
     <p>
       ⚫︎ <%= friend.username %>
       <% if (f = Friendship.status_between(current_user, friend)) == :friend %>
         <%= button_to "解除",
-                      friendship_path(Friendship.find_by(user: current_user, friend: friend) ||
-                                      Friendship.find_by(user: friend, friend: current_user)),
+                      friendship_path(Friendship.between(current_user, friend)),
                                       method: :delete,
                                       data: { turbo_confirm: "友達を解除しますか？" } %>
       <% end %>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -4,9 +4,9 @@
   <% @friends.each do |friend| %>
     <p>
       ⚫︎ <%= friend.username %>
-      <% if (f = Friendship.status_between(current_user, friend)) == :friend %>
+      <% if current_user.friend_with?(friend) %>
         <%= button_to "解除",
-                      friendship_path(Friendship.between(current_user, friend)),
+                      friendship_path(current_user.friendship_with(friend)),
                                       method: :delete,
                                       data: { turbo_confirm: "友達を解除しますか？" } %>
       <% end %>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -4,11 +4,11 @@
   <% @friends.each do |friend| %>
     <p>
       ⚫︎ <%= friend.username %>
-      <% if current_user.friend_with?(friend) %>
-        <%= button_to "解除",
-                      friendship_path(current_user.friendship_with(friend)),
-                                      method: :delete,
-                                      data: { turbo_confirm: "友達を解除しますか？" } %>
+      <% if (friendship = @friendships_by_friend_id[friend.id]) %>
+        <%= button_to '解除',
+                      friendship_path(friendship),
+                      method: :delete,
+                      data: { turbo_confirm: '友達を解除しますか？' } %>
       <% end %>
     </p>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 <% @users.each do |user| %>
   <p>
     <%= user.username %>
-    <% if Friendship.between(current_user, user) == :friend %>
+    <% if current_user.friend_with?(user) %>
       <span>友達</span>
     <% elsif (req = current_user.sent_request_to(user))&.pending? %>
       <span>申請中</span>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 <% @users.each do |user| %>
   <p>
     <%= user.username %>
-    <% if Friendship.status_between(current_user, user) == :friend %>
+    <% if Friendship.between(current_user, user) == :friend %>
       <span>友達</span>
     <% elsif (req = current_user.sent_request_to(user))&.pending? %>
       <span>申請中</span>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,6 +15,9 @@
                     method: :patch %>
     <% elsif (req = current_user.sent_request_to(user))&.rejected? %>
       <span>申請拒否済み</span>
+      <%= button_to "再申請",
+                    friend_request_path(req, status: :pending),
+                    method: :patch %>
     <% else %>
       <%= button_to "友達申請", friend_requests_path(friend_id: user.id), method: :post %>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,19 +7,23 @@
     <% elsif (req = current_user.sent_request_to(user))&.pending? %>
       <span>申請中</span>
     <% elsif (req = current_user.received_request_from(user))&.pending? %>
-      <%= button_to "承認する",
+      <%= button_to '承認する',
                     friend_request_path(req, status: :accepted),
                     method: :patch %>
-      <%= button_to "拒否する",
+      <%= button_to '拒否する',
                     friend_request_path(req, status: :rejected),
                     method: :patch %>
     <% elsif (req = current_user.sent_request_to(user))&.rejected? %>
       <span>申請拒否済み</span>
-      <%= button_to "再申請",
+      <%= button_to '再申請',
                     friend_request_path(req, status: :pending),
-                    method: :patch %>
+                    method: :patch,
+                    form: { data: { turbo: false } } %>
     <% else %>
-      <%= button_to "友達申請", friend_requests_path(friend_id: user.id), method: :post %>
+      <%= button_to '友達申請', 
+                    friend_requests_path(friend_id: user.id), 
+                    method: :post,
+                    form: { data: { turbo: false } } %>
     <% end %>
   </p>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,18 +2,20 @@
 <% @users.each do |user| %>
   <p>
     <%= user.username %>
-    <% case current_user.friendship_status_with(user) %>
-    <% when :friend %>
+    <% if Friendship.status_between(current_user, user) == :friend %>
       <span>友達</span>
-    <% when :request_sent %>
+    <% elsif (req = current_user.sent_request_to(user))&.pending? %>
       <span>申請中</span>
-    <% when :request_received %>
+    <% elsif (req = current_user.received_request_from(user))&.pending? %>
       <%= button_to "承認する",
-                    friend_request_path(current_user.received_request_from(user), status: :accepted),
+                    friend_request_path(req, status: :accepted),
                     method: :patch %>
-    <% when :request_rejected %>
+      <%= button_to "拒否する",
+                    friend_request_path(req, status: :rejected),
+                    method: :patch %>
+    <% elsif (req = current_user.sent_request_to(user))&.rejected? %>
       <span>申請拒否済み</span>
-    <% when :none %>
+    <% else %>
       <%= button_to "友達申請", friend_requests_path(friend_id: user.id), method: :post %>
     <% end %>
   </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root "home#index"
+  root 'home#index'
 
   devise_for :users
   resources :users, only: [:index]
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # 友達関係の管理
   resources :friendships, only: %i[index destroy]
 
-  get "up" => "rails/health#show", as: :rails_health_check
+  get 'up' => 'rails/health#show', as: :rails_health_check
 end

--- a/db/migrate/20251112133440_add_deleted_at_to_friendships.rb
+++ b/db/migrate/20251112133440_add_deleted_at_to_friendships.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToFriendships < ActiveRecord::Migration[7.1]
+  def change
+    add_column :friendships, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20251129053358_create_friendship_users.rb
+++ b/db/migrate/20251129053358_create_friendship_users.rb
@@ -1,0 +1,12 @@
+class CreateFriendshipUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :friendship_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :friendship, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :friendship_users, [:user_id, :friendship_id], unique: true
+  end
+end

--- a/db/migrate/20251129063321_change_friendships_to_use_join_table.rb
+++ b/db/migrate/20251129063321_change_friendships_to_use_join_table.rb
@@ -1,0 +1,6 @@
+class ChangeFriendshipsToUseJoinTable < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :friendships, :user, foreign_key: true
+    remove_reference :friendships, :friend, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20251210135146_remove_deleted_at_from_friendship.rb
+++ b/db/migrate/20251210135146_remove_deleted_at_from_friendship.rb
@@ -1,0 +1,5 @@
+class RemoveDeletedAtFromFriendship < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :friendships, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_12_133440) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_29_063321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,16 +25,21 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_12_133440) do
     t.index ["user_id"], name: "index_friend_requests_on_user_id"
   end
 
-  create_table "friendships", force: :cascade do |t|
+  create_table "friendship_users", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "friend_id", null: false
+    t.bigint "friendship_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["friendship_id"], name: "index_friendship_users_on_friendship_id"
+    t.index ["user_id", "friendship_id"], name: "index_friendship_users_on_user_id_and_friendship_id", unique: true
+    t.index ["user_id"], name: "index_friendship_users_on_user_id"
+  end
+
+  create_table "friendships", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.index ["friend_id"], name: "index_friendships_on_friend_id"
-    t.index ["user_id", "friend_id"], name: "index_friendships_on_user_id_and_friend_id", unique: true
-    t.index ["user_id"], name: "index_friendships_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,6 +59,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_12_133440) do
 
   add_foreign_key "friend_requests", "users"
   add_foreign_key "friend_requests", "users", column: "friend_id"
-  add_foreign_key "friendships", "users"
-  add_foreign_key "friendships", "users", column: "friend_id"
+  add_foreign_key "friendship_users", "friendships"
+  add_foreign_key "friendship_users", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_29_063321) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_10_135146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_29_063321) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_16_020006) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_12_133440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_16_020006) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["friend_id"], name: "index_friendships_on_friend_id"
     t.index ["user_id", "friend_id"], name: "index_friendships_on_user_id_and_friend_id", unique: true
     t.index ["user_id"], name: "index_friendships_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+User.find_or_create_by!(email: 'test@email.com') do |u|
+  u.password = 'password'
+  u.username = 'テストアカウント１'
+end
+
+User.find_or_create_by!(email: 'test2@example.com') do |u|
+  u.password = 'password'
+  u.username = 'testuser2'
+end

--- a/spec/helpers/friend_requests_helper_spec.rb
+++ b/spec/helpers/friend_requests_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FriendRequestsHelper. For example:
+#
+# describe FriendRequestsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FriendRequestsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/friendship_user_spec.rb
+++ b/spec/models/friendship_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FriendshipUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/friend_requests_spec.rb
+++ b/spec/requests/friend_requests_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "FriendRequests", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/friend_requests/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/friend_requests/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/friend_requests/create.html.erb_spec.rb
+++ b/spec/views/friend_requests/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "friend_requests/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/friend_requests/update.html.erb_spec.rb
+++ b/spec/views/friend_requests/update.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "friend_requests/update.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 2025/12/30
### 1. 友達申請（FriendRequestsController#create）
  - 自分自身への申請を防止
  - 既存の申請履歴がある場合は同一レコードをpendingに更新（履歴は保持）
  - 二重申請防止（pending状態の重複作成をガード）
  - 逆方向（相手→自分）のpendingが存在する場合、新規申請を停止
  - 承認/拒否/再申請の操作はupdateアクションでenum（ :accepted, :rejected, :pending）を分岐
### 2. 友達関係管理（Friendship / FriendshipUser）
  - Friendshipはactive/inactiveのenumで管理（直接SQLを使用しない構造へ修正）
  - １対１の関係をfriendships起点でモデル化
### 3. レビュー指摘対応
  - User.rb内でFriendshipクラス起点の呼び出しをUser.friendships起点へ統一（責務の自然さを改善）
  - マジックナンバーhaving = 2を撤廃、ActiveRecord中心の自然なRails構造へリファクタ
  - Rails作法として空行やシングルクォート統一反映 

## 2025/12/23
中間テーブルFriendshipUser 作成後の友達申請・承認・解除・拒否機能のリファクタリング

## 2025/12/2
1. FriendshipUser のマイグレーション作成
5. friendships テーブルから user_id / friend_id を外す
6. FriendshipUser モデルを作る
7. Friendship モデルの修正
8. User モデルのアソシエーションと friends メソッドの修正

## 2025/11/25
## Friendship モデルのリファクタリング
- 「AとBの関係を 1レコードだけ で表現」する
- 今の friendships テーブルのカラムは：
　・user_id（usersへのFK）
　・friend_id（usersへのFK）
　・status
　・deleted_at
 => 既に「ユーザーとユーザーの関係を表す 中間テーブル」

## 2025/11/18
## User ではなく Friendship モデルに「関係状態を知っている責務」を置く方が自然
- Friendship モデルに責務を移す

## 論理削除にて友達関係の解除
- マイグレーションでadd_column :friendships, :deleted_at, :datetimeを追加
- friendships/index.html.erbの整備
-  コントローラーdestroyアクションへ論理削除を記述

## 友達解除時は、deleted_at = Time.current を更新する