### PR TITLE
fix: レビュー(5/11) 対応_「環境変数ないときバグりそう」「フレンド関係にないユーザーのIDをPOSTすれば、誰とでもルームを作れてしまう」

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -8,8 +8,8 @@ module ApplicationCable
 
     private
       def find_verified_user
-        if verrified_user = env['warden'].user
-          verrified_user
+        if verified_user = env['warden']&.user
+          verified_user
         else
           reject_unauthorized_connection
         end

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -46,8 +46,10 @@ class ChatRoomsController < ApplicationController
     def create_params
       p = params.permit(user_ids: [])
 
+      friend_ids = current_user.friends.pluck(:id)
+
       user_ids = (p[:user_ids] || []).map(&:to_i)
-                                    .select { |id| id.positive? && id != current_user.id }
+                                    .select { |id| id.positive? && friend_ids.include?(id) }
 
       { user_ids: user_ids }
     end
@@ -66,5 +68,4 @@ class ChatRoomsController < ApplicationController
       n = raw.to_i
       [n, 1].max
     end
-    
 end


### PR DESCRIPTION
① 友達以外のIDを弾くチェック追加
② &. でnil安全に + タイポ修正