### PR TITLE
fix: チャット検索のスコープをユーザー内に制限、メッセージ削除時のエラーハンドリングを追加

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,13 +2,11 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = ChatRoom.find(chat_room_id)
+    @chat_room = current_user.chat_rooms.find(params[:chat_room_id])
 
-    unless @chat_room.member?(current_user)
-      return head :forbidden
-    end
-
-    @message = @chat_room.messages.build(message_params.merge(user: current_user))
+    @message = @chat_room.messages.build(
+      message_params.merge(user: current_user)
+    )
 
     if @message.save
       @message = Message.new
@@ -28,28 +26,19 @@ class MessagesController < ApplicationController
   end
   
   def destroy
-    @chat_room = ChatRoom.find(chat_room_id)
-    @message = @chat_room.messages.find(destroy_params)
+    @message = current_user.messages.find(params[:id])
 
-    if @message.user_id == current_user.id
-      @message.destroy
+    if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
     else
-      head :forbidden
+      head :unprocessable_entity
     end
   end
 
   private
-
-    def chat_room_id
-      params[:chat_room_id]
-    end
   
     def message_params
       params.require(:message).permit(:body)
     end
-  
-    def destroy_params
-      params[:id]
-    end
+    
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = current_user.chat_rooms.find(create_params)
+    @chat_room = current_user.chat_rooms.find(params[:chat_room_id])
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -24,9 +24,9 @@ class MessagesController < ApplicationController
       ), status: :unprocessable_entity
     end
   end
-  
+
   def destroy
-    @message = current_user.messages.find(destroy_params)
+    @message = current_user.messages.find(params[:id])
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -36,16 +36,8 @@ class MessagesController < ApplicationController
   end
 
   private
-  
-    def create_params
-      params.require(:chat_room_id)
-    end
 
     def message_params
       params.require(:message).permit(:body)
-    end
-    
-    def destroy_params
-      params.require(:id)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,8 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = current_user.chat_rooms.find(params[:chat_room_id])
+    inputs = create_params
+    @chat_room = current_user.chat_rooms.find(inputs[:chat_room_id])
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -26,7 +27,8 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    @message = current_user.messages.find(params[:id])
+    inputs = destroy_params
+    @message = current_user.messages.find(inputs[:id])
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -37,7 +39,15 @@ class MessagesController < ApplicationController
 
   private
 
+    def create_params
+      params.permit(:chat_room_id)
+    end
+
     def message_params
       params.require(:message).permit(:body)
+    end
+
+    def destroy_params
+      params.permit(:id)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = current_user.chat_rooms.find(create_param[:chat_room_id])
+    @chat_room = current_user.chat_rooms.find(create_params[:chat_room_id])
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -26,7 +26,7 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    @message = current_user.messages.find(destroy_param[:id])
+    @message = current_user.messages.find(destroy_params[:id])
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -36,17 +36,17 @@ class MessagesController < ApplicationController
   end
 
   private
-    # param：単一値取得
-    # params：属性ハッシュ/複数値取得
-    def create_param
-      params.permit(:chat_room_id)
-    end
 
     def message_params
       params.require(:message).permit(:body)
     end
 
-    def destroy_param
+    # ルート由来のスカラー値だが_paramsの命名規約に揃える
+    def create_params
+      params.permit(:chat_room_id)
+    end
+
+    def destroy_params
       params.permit(:id)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = current_user.chat_rooms.find(create_params[:chat_room_id])
+    @chat_room = current_user.chat_rooms.find(params[:chat_room_id])
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -26,7 +26,7 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    @message = current_user.messages.find(destroy_params[:id])
+    @message = current_user.messages.find(params[:id])
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -39,14 +39,5 @@ class MessagesController < ApplicationController
 
     def message_params
       params.require(:message).permit(:body)
-    end
-
-    # ルート由来のスカラー値だが_paramsの命名規約に揃える
-    def create_params
-      params.permit(:chat_room_id)
-    end
-
-    def destroy_params
-      params.permit(:id)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @chat_room = current_user.chat_rooms.find(params[:chat_room_id])
+    @chat_room = current_user.chat_rooms.find(create_params)
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -26,7 +26,7 @@ class MessagesController < ApplicationController
   end
   
   def destroy
-    @message = current_user.messages.find(params[:id])
+    @message = current_user.messages.find(destroy_params)
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -37,8 +37,15 @@ class MessagesController < ApplicationController
 
   private
   
+    def create_params
+      params.require(:chat_room_id)
+    end
+
     def message_params
       params.require(:message).permit(:body)
     end
     
+    def destroy_params
+      params.require(:id)
+    end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,8 +2,7 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    inputs = create_params
-    @chat_room = current_user.chat_rooms.find(inputs[:chat_room_id])
+    @chat_room = current_user.chat_rooms.find(create_param[:chat_room_id])
 
     @message = @chat_room.messages.build(
       message_params.merge(user: current_user)
@@ -27,8 +26,7 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    inputs = destroy_params
-    @message = current_user.messages.find(inputs[:id])
+    @message = current_user.messages.find(destroy_param[:id])
 
     if @message.destroy
       render turbo_stream: turbo_stream.remove(@message)
@@ -38,8 +36,9 @@ class MessagesController < ApplicationController
   end
 
   private
-
-    def create_params
+    # param：単一値取得
+    # params：属性ハッシュ/複数値取得
+    def create_param
       params.permit(:chat_room_id)
     end
 
@@ -47,7 +46,7 @@ class MessagesController < ApplicationController
       params.require(:message).permit(:body)
     end
 
-    def destroy_params
+    def destroy_param
       params.permit(:id)
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   # チャットルームとメッセージの管理
   resources :chat_rooms, only: %i[index create show] do
-    resources :messages, only: %i[create destroy]
+    resources :messages, only: %i[create destroy edit update]
   end
 
   get 'up' => 'rails/health#show', as: :rails_health_check


### PR DESCRIPTION
レビュー指摘対応
1. destory失敗時の処理がない　
  → if / else でhead :unprocessable_entityを追加

3. ChatRoom.findを起点とすることの違和感
  → current_user.chat_rooms.find / current_user.messages.findに変更