### PR TITLE
refactor: 不要になったルートと未使用ビューの削除

### DIFF
--- a/app/views/friend_requests/create.html.erb
+++ b/app/views/friend_requests/create.html.erb
@@ -1,2 +1,0 @@
-<h1>FriendRequests#create</h1>
-<p>Find me in app/views/friend_requests/create.html.erb</p>

--- a/app/views/friend_requests/update.html.erb
+++ b/app/views/friend_requests/update.html.erb
@@ -1,2 +1,0 @@
-<h1>FriendRequests#update</h1>
-<p>Find me in app/views/friend_requests/update.html.erb</p>

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Messages#create</h1>
-<p>Find me in app/views/messages/create.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   # チャットルームとメッセージの管理
   resources :chat_rooms, only: %i[index create show] do
-    resources :messages, only: %i[create destroy edit update]
+    resources :messages, only: %i[create destroy]
   end
 
   get 'up' => 'rails/health#show', as: :rails_health_check


### PR DESCRIPTION
## 概要
- チャットのメッセージ編集機能を実装予定だったが、LINE準拠のアプリ方針に照らし不要と判断。着手前だったため、routesの定義のみ削除する
- routesの修正
- ジェネレータで生成されるviewsの削除

## 変更内容
- config/routes.rb — messages から edit / update を削除
- 未使用の雛形ビュー3ファイル — messages/create.html.erb、friend_requests/create.html.erb、friend_requests/update.html.erb